### PR TITLE
Add salary field

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -43,6 +43,7 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       status: "Bookmarked",
       interestLevel: "Medium",
       notes: "",
+      targetSalary: "",
     },
   });
 
@@ -104,6 +105,25 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
                   {...field}
                   value={field.value ?? ""}
                   data-testid="input-job-url"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="targetSalary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Target Salary (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder='e.g. $120,000 or 120k-150k'
+                  {...field}
+                  value={field.value ?? ""}
+                  data-testid="input-target-salary"
                 />
               </FormControl>
               <FormMessage />

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -48,6 +48,7 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
       notes: prospect.notes ?? "",
+      targetSalary: prospect.targetSalary ?? "",
     },
   });
 
@@ -108,6 +109,25 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
                   {...field}
                   value={field.value ?? ""}
                   data-testid="input-edit-job-url"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="targetSalary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Target Salary (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder='e.g. $120,000 or 120k-150k'
+                  {...field}
+                  value={field.value ?? ""}
+                  data-testid="input-edit-target-salary"
                 />
               </FormControl>
               <FormMessage />

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, DollarSign } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -104,6 +104,12 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
 
         <div className="flex items-center gap-1.5 flex-wrap">
           <InterestIndicator level={prospect.interestLevel} />
+          {prospect.targetSalary && (
+            <span className="inline-flex items-center gap-1 text-xs text-muted-foreground" data-testid={`text-salary-${prospect.id}`}>
+              <DollarSign className="w-3 h-3" />
+              {prospect.targetSalary}
+            </span>
+          )}
         </div>
 
         {prospect.jobUrl && (

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -21,3 +21,59 @@ describe("prospect creation validation", () => {
     expect(result.errors).toContain("Role title is required");
   });
 });
+
+describe("salary field validation", () => {
+  test("accepts a prospect with no salary field", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts a dollar-formatted salary string", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+      targetSalary: "$120,000",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts a range salary string", () => {
+    const result = validateProspect({
+      companyName: "Stripe",
+      roleTitle: "PM",
+      targetSalary: "120k-150k",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts a free-form salary string", () => {
+    const result = validateProspect({
+      companyName: "Meta",
+      roleTitle: "Designer",
+      targetSalary: "negotiable",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts an empty string salary (treated as no salary)", () => {
+    const result = validateProspect({
+      companyName: "Amazon",
+      roleTitle: "Analyst",
+      targetSalary: "",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -39,6 +39,7 @@ export async function registerRoutes(
     if (body.roleTitle !== undefined) updates.roleTitle = body.roleTitle;
     if (body.jobUrl !== undefined) updates.jobUrl = body.jobUrl;
     if (body.notes !== undefined) updates.notes = body.notes;
+    if (body.targetSalary !== undefined) updates.targetSalary = body.targetSalary;
 
     if (body.status !== undefined) {
       if (!STATUSES.includes(body.status)) {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -22,6 +22,7 @@ export const prospects = pgTable("prospects", {
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
   notes: text("notes"),
+  targetSalary: text("target_salary"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
@@ -35,6 +36,7 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
   jobUrl: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
+  targetSalary: z.string().optional().nullable(),
 });
 
 export type InsertProspect = z.infer<typeof insertProspectSchema>;


### PR DESCRIPTION
Adds a `targetSalary` text field to the prospects table, forms, and card display, with associated backend route and frontend validation tests.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 95a7df72-5f79-4a77-bb6d-4948134990ea
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 3e95623e-75fa-4863-8b42-23b279301d68
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/3e1fe72c-1923-4fc5-bed0-c1273e3d29d8/95a7df72-5f79-4a77-bb6d-4948134990ea/5k24P2E
Replit-Helium-Checkpoint-Created: true