### PR TITLE
Add contact person field to job tracker application for prospect details

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -44,6 +44,7 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       interestLevel: "Medium",
       notes: "",
       targetSalary: "",
+      contactPerson: "",
     },
   });
 
@@ -105,6 +106,25 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
                   {...field}
                   value={field.value ?? ""}
                   data-testid="input-job-url"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="contactPerson"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Contact Person (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder='e.g. Jane Smith or Jane Smith - jane@company.com'
+                  {...field}
+                  value={field.value ?? ""}
+                  data-testid="input-contact-person"
                 />
               </FormControl>
               <FormMessage />

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -49,6 +49,7 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
       notes: prospect.notes ?? "",
       targetSalary: prospect.targetSalary ?? "",
+      contactPerson: prospect.contactPerson ?? "",
     },
   });
 
@@ -109,6 +110,25 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
                   {...field}
                   value={field.value ?? ""}
                   data-testid="input-edit-job-url"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="contactPerson"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Contact Person (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder='e.g. Jane Smith or Jane Smith - jane@company.com'
+                  {...field}
+                  value={field.value ?? ""}
+                  data-testid="input-edit-contact-person"
                 />
               </FormControl>
               <FormMessage />

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, DollarSign } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, DollarSign, User } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -111,6 +111,13 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
             </span>
           )}
         </div>
+
+        {prospect.contactPerson && (
+          <p className="inline-flex items-center gap-1 text-xs text-muted-foreground truncate" data-testid={`text-contact-${prospect.id}`}>
+            <User className="w-3 h-3 shrink-0" />
+            {prospect.contactPerson}
+          </p>
+        )}
 
         {prospect.jobUrl && (
           <a

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -77,3 +77,59 @@ describe("salary field validation", () => {
     expect(result.errors).toHaveLength(0);
   });
 });
+
+describe("contact person field validation", () => {
+  test("accepts a prospect with no contact person field", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts a name-only contact string", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Engineer",
+      contactPerson: "Jane Smith",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts a name with email contact string", () => {
+    const result = validateProspect({
+      companyName: "Stripe",
+      roleTitle: "PM",
+      contactPerson: "Jane Smith - jane@company.com",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts a name with phone contact string", () => {
+    const result = validateProspect({
+      companyName: "Meta",
+      roleTitle: "Designer",
+      contactPerson: "John Doe - 555-123-4567",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts an empty string contact (treated as no contact)", () => {
+    const result = validateProspect({
+      companyName: "Amazon",
+      roleTitle: "Analyst",
+      contactPerson: "",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -40,6 +40,7 @@ export async function registerRoutes(
     if (body.jobUrl !== undefined) updates.jobUrl = body.jobUrl;
     if (body.notes !== undefined) updates.notes = body.notes;
     if (body.targetSalary !== undefined) updates.targetSalary = body.targetSalary;
+    if (body.contactPerson !== undefined) updates.contactPerson = body.contactPerson;
 
     if (body.status !== undefined) {
       if (!STATUSES.includes(body.status)) {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -23,6 +23,7 @@ export const prospects = pgTable("prospects", {
   interestLevel: text("interest_level").notNull().default("Medium"),
   notes: text("notes"),
   targetSalary: text("target_salary"),
+  contactPerson: text("contact_person"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
@@ -37,6 +38,7 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   jobUrl: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
   targetSalary: z.string().optional().nullable(),
+  contactPerson: z.string().optional().nullable(),
 });
 
 export type InsertProspect = z.infer<typeof insertProspectSchema>;


### PR DESCRIPTION
Adds a new optional "Contact Person" field to the prospect tracking application, including frontend form updates, backend database storage, prospect card display, and comprehensive validation tests.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 95a7df72-5f79-4a77-bb6d-4948134990ea
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: a336e837-8eac-4e79-9d29-1dc3816638b4
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/3e1fe72c-1923-4fc5-bed0-c1273e3d29d8/95a7df72-5f79-4a77-bb6d-4948134990ea/iz0KLJb
Replit-Helium-Checkpoint-Created: true